### PR TITLE
refactor: Add reference generation step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,10 +43,14 @@ jobs:
           package_version: ${{ steps.get_versions.outputs.package_version }}
 
       - name: 'Generate package reference files'
+        id: generate_reference_files
         run: |
           npm install dev-otta/metadatareference
 
           packages=($(find ${{ steps.move_packages.outputs.archive_dir }} -type f -name "*.json" | sort))
+
+          complete_package_dir="${{ steps.move_packages.outputs.package_code }}_COMPLETE_${{ steps.get_versions.outputs.package_version }}_DHIS${{ steps.get_versions.outputs.dhis2_version }}"
+          echo "::set-output name=complete_package_dir::$complete_package_dir"
 
           for package_path in "${packages[@]}"
           do
@@ -56,12 +60,13 @@ jobs:
 
             sudo node ../../node_modules/metadatareference/reference.js $package_name
 
-            if [[ $(basename $(dirname $package_path)) == "COMPLETE" ]]; then
-              cp "${package_name%.*}.xlsx" testfile.xlsx
+            if [[ $(basename $(dirname $package_path)) == "$complete_package_dir" ]]; then
+              echo "::set-output name=complete_package_reference_file::${package_name%.*}.xlsx"
             fi
 
             cd -
           done
+        shell: bash -ex {0}
 
       - name: 'Checkout master branch'
         uses: actions/checkout@v2
@@ -96,6 +101,15 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           source: "${{ steps.move_packages.outputs.archive_dir }}.zip"
           dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip"
+
+      - name: 'Upload reference file from COMPLETE package'
+        uses: prewk/s3-cp-action@v2
+        with:
+          aws_access_key_id: ${{ secrets.BOT_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.BOT_SECRET_KEY }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          source: "${{ steps.move_packages.outputs.archive_dir }}/${{ steps.generate_reference_files.outputs.complete_package_dir }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
+          dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
 
       - name: 'Get release notes file'
         id: get_release_notes

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: 'Prepare packages for archiving'
         id: move_packages
-        uses: dhis2-metadata/prepare@remove-reference-file-step
+        uses: dhis2-metadata/prepare@v1
         with:
           working_dir: 'feature'
           package_version: ${{ steps.get_versions.outputs.package_version }}
@@ -54,19 +54,16 @@ jobs:
 
           for package_path in "${packages[@]}"
           do
-            cd $(dirname $package_path)
+            cd "$GITHUB_WORKSPACE/$(dirname $package_path)"
 
             package_name=$(basename $package_path)
 
-            sudo node ../../node_modules/metadatareference/reference.js $package_name
+            sudo node $GITHUB_WORKSPACE/node_modules/metadatareference/reference.js $package_name
 
             if [[ $(basename $(dirname $package_path)) == "$complete_package_dir" ]]; then
               echo "::set-output name=complete_package_reference_file::${package_name%.*}.xlsx"
             fi
-
-            cd -
           done
-        shell: bash -ex {0}
 
       - name: 'Checkout master branch'
         uses: actions/checkout@v2
@@ -103,6 +100,7 @@ jobs:
           dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip"
 
       - name: 'Upload reference file from COMPLETE package'
+        if: ${{ steps.generate_reference_files.outputs.complete_package_reference_file }}
         uses: prewk/s3-cp-action@v2
         with:
           aws_access_key_id: ${{ secrets.BOT_ACCESS_KEY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,10 +37,31 @@ jobs:
 
       - name: 'Prepare packages for archiving'
         id: move_packages
-        uses: dhis2-metadata/prepare@v1
+        uses: dhis2-metadata/prepare@remove-reference-file-step
         with:
           working_dir: 'feature'
           package_version: ${{ steps.get_versions.outputs.package_version }}
+
+      - name: 'Generate package reference files'
+        run: |
+          npm install dev-otta/metadatareference
+
+          packages=($(find ${{ steps.move_packages.outputs.archive_dir }} -type f -name "*.json" | sort))
+
+          for package_path in "${packages[@]}"
+          do
+            cd $(dirname $package_path)
+
+            package_name=$(basename $package_path)
+
+            sudo node ../../node_modules/metadatareference/reference.js $package_name
+
+            if [[ $(basename $(dirname $package_path)) == "COMPLETE" ]]; then
+              cp "${package_name%.*}.xlsx" testfile.xlsx
+            fi
+
+            cd -
+          done
 
       - name: 'Checkout master branch'
         uses: actions/checkout@v2


### PR DESCRIPTION
Adding a step to generate package reference files "on the fly" before uploading the package archive to S3. 

The reference file from the `COMPLETE` package (if it exists) is also uploaded separately from the archive at the same location in S3.

Related to https://github.com/dhis2-metadata/prepare/pull/2