### PR TITLE
refactor: Use standard-release-notes action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,7 +97,12 @@ jobs:
           aws_secret_access_key: ${{ secrets.BOT_SECRET_KEY }}
           aws_region: ${{ secrets.AWS_REGION }}
           source: "${{ steps.move_packages.outputs.archive_dir }}.zip"
-          dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip"
+          dest: "s3://${{ secrets.S3_BUCKET }}\
+            /${{ steps.move_packages.outputs.package_locale }}\
+            /${{ steps.move_packages.outputs.package_code }}\
+            /${{ steps.get_versions.outputs.package_version }}\
+            /DHIS${{ steps.get_versions.outputs.dhis2_version }}\
+            /${{ steps.move_packages.outputs.archive_dir }}.zip"
 
       - name: 'Upload reference file from COMPLETE package'
         if: ${{ steps.generate_reference_files.outputs.complete_package_reference_file }}
@@ -106,17 +111,21 @@ jobs:
           aws_access_key_id: ${{ secrets.BOT_ACCESS_KEY }}
           aws_secret_access_key: ${{ secrets.BOT_SECRET_KEY }}
           aws_region: ${{ secrets.AWS_REGION }}
-          source: "${{ steps.move_packages.outputs.archive_dir }}/${{ steps.generate_reference_files.outputs.complete_package_dir }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
-          dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
-
-#      - name: 'Get release notes file'
-#        id: get_release_notes
-#        run: echo "::set-output name=release_notes::$(find . -name *release_note-${{ steps.get_versions.outputs.package_version }}.md)"
+          source: "${{ steps.move_packages.outputs.archive_dir }}\
+            /${{ steps.generate_reference_files.outputs.complete_package_dir }}\
+            /${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
+          dest: "s3://${{ secrets.S3_BUCKET }}\
+            /${{ steps.move_packages.outputs.package_locale }}\
+            /${{ steps.move_packages.outputs.package_code }}\
+            /${{ steps.get_versions.outputs.package_version }}\
+            /DHIS${{ steps.get_versions.outputs.dhis2_version }}\
+            /${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
 
       - name: 'Get Release notes'
         uses: yashanand1910/standard-release-notes@v1.2.1
         id: get_release_notes
         with:
+          changelog_path: ./docs/release_note.md
           version: ${{ github.ref_name }}
 
       - name: 'Find release ID'
@@ -132,5 +141,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           id: ${{ steps.find_release.outputs.id }}
-          body: "Package uploaded to https://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip\n${{ steps.get_release_notes.outputs.release_notes }}"
-          files: "${{ steps.get_release_notes.outputs.release_notes }}"
+          body: "Package uploaded to https://${{ secrets.S3_BUCKET }}\
+            /${{ steps.move_packages.outputs.package_locale }}\
+            /${{ steps.move_packages.outputs.package_code }}\
+            /${{ steps.get_versions.outputs.package_version }}\
+            /DHIS${{ steps.get_versions.outputs.dhis2_version }}\
+            /${{ steps.move_packages.outputs.archive_dir }}.zip\n\
+            ${{ steps.get_release_notes.outputs.release_notes }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -109,9 +109,15 @@ jobs:
           source: "${{ steps.move_packages.outputs.archive_dir }}/${{ steps.generate_reference_files.outputs.complete_package_dir }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
           dest: "s3://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.generate_reference_files.outputs.complete_package_reference_file }}"
 
-      - name: 'Get release notes file'
+#      - name: 'Get release notes file'
+#        id: get_release_notes
+#        run: echo "::set-output name=release_notes::$(find . -name *release_note-${{ steps.get_versions.outputs.package_version }}.md)"
+
+      - name: 'Get Release notes'
+        uses: yashanand1910/standard-release-notes@v1.2.1
         id: get_release_notes
-        run: echo "::set-output name=release_notes::$(find . -name *release_note-${{ steps.get_versions.outputs.package_version }}.md)"
+        with:
+          version: ${{ github.ref_name }}
 
       - name: 'Find release ID'
         id: find_release
@@ -126,5 +132,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           id: ${{ steps.find_release.outputs.id }}
-          body: "Package uploaded to https://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip"
+          body: "Package uploaded to https://${{ secrets.S3_BUCKET }}/${{ steps.move_packages.outputs.package_locale }}/${{ steps.move_packages.outputs.package_code }}/${{ steps.get_versions.outputs.package_version }}/DHIS${{ steps.get_versions.outputs.dhis2_version }}/${{ steps.move_packages.outputs.archive_dir }}.zip\n${{ steps.get_release_notes.outputs.release_notes }}"
           files: "${{ steps.get_release_notes.outputs.release_notes }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -125,8 +125,8 @@ jobs:
         uses: yashanand1910/standard-release-notes@v1.2.1
         id: get_release_notes
         with:
-          changelog_path: ./docs/release_note.md
-          version: ${{ github.ref_name }}
+          changelog_path: master/docs/release_note.md
+          version: ${{ steps.get_versions.outputs.package_version }}
 
       - name: 'Find release ID'
         id: find_release
@@ -146,5 +146,5 @@ jobs:
             /${{ steps.move_packages.outputs.package_code }}\
             /${{ steps.get_versions.outputs.package_version }}\
             /DHIS${{ steps.get_versions.outputs.dhis2_version }}\
-            /${{ steps.move_packages.outputs.archive_dir }}.zip\n\
+            /${{ steps.move_packages.outputs.archive_dir }}.zip\n\n\
             ${{ steps.get_release_notes.outputs.release_notes }}"


### PR DESCRIPTION
We are moving to a continous changelog-style release notes file and we can start using the [standard-release-notes](https://github.com/marketplace/actions/standard-release-notes) action for taking the relevant version part of it for the GitHub release notes.